### PR TITLE
[Bug#45431] User - Fix logic update quantity in session cart of create method 

### DIFF
--- a/app/helpers/carts_helper.rb
+++ b/app/helpers/carts_helper.rb
@@ -17,7 +17,7 @@ module CartsHelper
   end
 
   def find_book_in_cart book
-    current_cart.find{|book_id, quantity| book_id == book.id}
+    current_cart.find{|book_id, quantity| book_id == book.id.to_s}
   end
 
   def total_loan_books


### PR DESCRIPTION
## Related Tickets:
- [#45431](https://edu-redmine.sun-asterisk.vn/issues/45431)

## WHAT this PR does?
**Description**

- *Bug parent* : Cannot update quantity in session cart when increasing number of loaned books.

  - *Bug child*    : Session cart still updates over permission quantity before checks quantity

**Fix :+1:** 

1. Bug parent

> Change `item[@book.id] += params[:quantity].to_i ` to `current_cart[@book.id.to_s] += params[:quantity].to_i`
> Convert `book.id` to `book.id.to_s`  - method find_book_in_cart

2. Bug child

> Check condition of quantity before update session cart.

## Attachments:

![Screenshot from 2022-01-20 14-58-13](https://user-images.githubusercontent.com/45041942/150296971-f6333a6a-a64b-4785-a664-b65485ac815f.png)

![Screenshot from 2022-01-20 14-54-01](https://user-images.githubusercontent.com/45041942/150296604-bab8d245-5ee0-4c85-900b-3824f20f15ce.png)

